### PR TITLE
Make the local numpy iterator memory efficient

### DIFF
--- a/autofaiss/datasets/readers/local_iterators.py
+++ b/autofaiss/datasets/readers/local_iterators.py
@@ -2,7 +2,7 @@
 
 import os
 import re
-from typing import Iterator, List
+from typing import Iterator, Optional
 
 import numpy as np
 from tqdm import tqdm as tq
@@ -32,17 +32,26 @@ def read_shapes_local(local_path: str, reg_exp_pattern: str = r".+\.npy") -> Ite
         yield shape
 
 
-def read_embeddings_local(local_embeddings_path: str, stack_input: int = 1, verbose=True) -> Iterator[np.ndarray]:
+def read_embeddings_local(
+    local_embeddings_path: str, batch_size: Optional[int] = None, verbose=True, reg_exp_pattern: str = r".+\.npy",
+) -> Iterator[np.ndarray]:
     """
     Iterate over embeddings arrays saved on disk.
     It is possible to iterate over batchs of files and yield stacked embeddings arrays.
+
+    The implementation adopted here is chosen for memory concern: it is very important
+    for autofaiss to avoid using more memory than necessary.
+    In particular, for the faiss training, a large embedding array is nessary.
+    It is not possible to save it twice in memory.
+    This implementation pre-allocate an array of size batch_size and keep it updated during the iteration over files.
+    The maximum memory usage is batch_size * dim * 4
 
     Parameters
     ----------
     local_embeddings_path : str
         Path on local disk of the embedding in numpy format.
-    stack_input : int (default 1)
-        Number of arrays that should be stacked at each iterations.
+    batch_size : int (default None)
+        Outputs a maximum of batch_size vectors, the default is the size of the first file
         This parameter is useful when working with many small files.
     verbose : bool
         Print detailed informations if set to True
@@ -52,58 +61,48 @@ def read_embeddings_local(local_embeddings_path: str, stack_input: int = 1, verb
     embeddings_iterator : Iterator[np.ndarray]
         An iterator over batchs of stacked embedding arrays.
     """
-    return read_arrays_local(local_embeddings_path, stack_input=stack_input, verbose=verbose)
+    try:
+        first_vector_count, dim = next(read_shapes_local(local_embeddings_path, reg_exp_pattern))
+    except StopIteration as err:
+        raise Exception("no files to read from") from err
 
-
-def read_arrays_local(
-    local_path: str, reg_exp_pattern: str = r".+\.npy", stack_input: int = 1, verbose=True
-) -> Iterator[np.ndarray]:
-    """
-    Iterate over numpy array files that match the reg ex pattern and yield their content.
-    It is possible to iterate over the stacked content of several arrays.
-
-    Parameters
-    ----------
-    local_embeddings_path : str
-        Path on local disk of arrays in numpy format.
-    stack_input : int (default 1)
-        Number of arrays that should be stacked at each iterations.
-        This parameter is useful when working with many small files.
-    verbose : bool
-        Print detailed informations if set to True
-
-    Returns
-    -------
-    arrays_iterator : Iterator[np.ndarray]
-        An iterator over batchs of stacked arrays.
-    """
-
-    assert stack_input > 0
+    if batch_size is None:
+        batch_size = first_vector_count
 
     reg_exp = re.compile(reg_exp_pattern)
 
-    filenames = os.walk(local_path).__next__()[2]
+    filenames = os.walk(local_embeddings_path).__next__()[2]
     filenames = [filename for filename in filenames if reg_exp.match(filename)]
     filenames.sort()
-    embeddings_stack: List[np.ndarray] = []
+    embeddings_batch = None
+    nb_emb_in_batch = 0
 
-    iterator = enumerate(filenames)
+    iterator = filenames
     if verbose:
         iterator = tq(list(iterator))
 
-    for file_number, file_name in iterator:
+    for file_name in iterator:
+        emb = np.load(f"{local_embeddings_path}/{file_name}", mmap_mode="r")
+        vec_size = emb.shape[0]
+        current_emb_index = 0
+        while True:
+            left_in_emb = vec_size - current_emb_index
+            remaining_to_add = max(batch_size - nb_emb_in_batch, 0)
+            adding = min(remaining_to_add, left_in_emb)
+            additional = max(left_in_emb - adding, 0)
+            if embeddings_batch is None:
+                embeddings_batch = np.empty((batch_size, dim), "float32")
+            embeddings_batch[nb_emb_in_batch : (nb_emb_in_batch + adding), :] = emb[
+                current_emb_index : (current_emb_index + adding), :
+            ]
+            nb_emb_in_batch += adding
+            current_emb_index += adding
+            if nb_emb_in_batch == batch_size:
+                yield embeddings_batch
+                nb_emb_in_batch = 0
+                embeddings_batch = None
+            if additional == 0:
+                break
 
-        if embeddings_stack and (file_number % stack_input == 0):
-            yield np.concatenate(embeddings_stack)
-            embeddings_stack = []
-
-        try:
-            emb = np.load(f"{local_path}/{file_name}")
-            if emb.dtype != "float32":
-                emb = emb.astype("float32")
-            embeddings_stack.append(emb)
-        except Exception as e:  # pylint: disable=broad-except
-            print(e)
-
-    if embeddings_stack:
-        yield np.concatenate(embeddings_stack).astype(np.float32)
+    if nb_emb_in_batch > 0 and embeddings_batch is not None:
+        yield embeddings_batch[:nb_emb_in_batch]

--- a/autofaiss/external/optimize.py
+++ b/autofaiss/external/optimize.py
@@ -48,13 +48,14 @@ def get_optimal_train_size(
     return train_size
 
 
-def get_optimal_batch_size(nb_vectors: int, vec_dim: int, current_memory_available: str) -> int:
-    """compute optimal batch size to use the RAM at its full potential"""
+def get_optimal_batch_size(vec_dim: int, current_memory_available: str) -> int:
+    """compute optimal batch size to use the RAM at its full potential for adding vectors"""
 
-    total_size = nb_vectors * vec_dim * 4  # in bytes
     memory = cast_memory_to_bytes(current_memory_available)
 
-    batch_size = int(0.5 * total_size / memory)
+    batch_size = min(
+        2 ** 14, int(memory / (vec_dim * 4))
+    )  # larger batch size than 16384 do not improve add speed and consume more ram
 
     return batch_size
 

--- a/autofaiss/external/quantize.py
+++ b/autofaiss/external/quantize.py
@@ -8,7 +8,6 @@ from typing import Dict, Optional, Union
 import faiss
 
 import fire
-from autofaiss.datasets.readers.local_iterators import read_embeddings_local
 from autofaiss.external.build import (
     build_index,
     estimate_memory_required_for_index_creation,
@@ -83,6 +82,10 @@ class Quantizer:
                 necessary_mem, index_key_used = estimate_memory_required_for_index_creation(
                     nb_vectors, vec_dim, index_key, max_index_memory_usage
                 )
+                print(
+                    f"{cast_bytes_to_memory_string(necessary_mem)} of memory "
+                    "will be needed to train the index (more might be used if you have more)"
+                )
 
                 prefix = "(default) " if index_key is None else ""
 
@@ -98,7 +101,6 @@ class Quantizer:
 
             if index_key is None:
                 with Timeit("Selecting most promising index types given data characteristics", indent=1):
-                    _, vec_dim = next(read_embeddings_local(embeddings_path, verbose=False)).shape
                     best_index_keys = get_optimal_index_keys_v2(nb_vectors, vec_dim, max_index_memory_usage)
                     if not best_index_keys:
                         return "Constraint on memory too high, no index can be that small"

--- a/autofaiss/indices/memory_efficient_flat_index.py
+++ b/autofaiss/indices/memory_efficient_flat_index.py
@@ -229,7 +229,7 @@ class MemEfficientFlatIndex(FaissIndexWrapper):
 
         return D, I
 
-    def search_files(self, x: np.ndarray, k: int, stack_input: int = 1):
+    def search_files(self, x: np.ndarray, k: int, batch_size: Optional[int] = None):
 
         if self.prod_emb_path is None:
             raise ValueError("The index is empty")
@@ -248,7 +248,7 @@ class MemEfficientFlatIndex(FaissIndexWrapper):
         offset = 0
 
         # For each batch
-        for emb_array in read_embeddings_local(self.prod_emb_path, stack_input, verbose=True):
+        for emb_array in read_embeddings_local(self.prod_emb_path, batch_size, verbose=True):
             # for i in trange(0, self.prod_emb.shape[0], batch_size):
 
             # instanciate a Flat index

--- a/tests/unit/test_local_iterators.py
+++ b/tests/unit/test_local_iterators.py
@@ -1,0 +1,44 @@
+import numpy as np
+import random
+from autofaiss.datasets.readers.local_iterators import read_embeddings_local
+import shutil
+import os
+
+
+def build_test_collection(min_size=2, max_size=10000, dim=512, nb_files=5):
+    tmp_dir = "/tmp/autofaiss_test"
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)
+    os.mkdir(tmp_dir)
+    sizes = [random.randint(min_size, max_size) for _ in range(nb_files)]
+    dim = dim
+    for i, size in enumerate(sizes):
+        arr = np.random.rand(size, dim).astype("float32")
+        np.save(str(tmp_dir) + "/" + str(i) + ".npy", arr)
+    return tmp_dir, sizes, dim
+
+
+def test_read_embeddings_local():
+    tmp_dir, sizes, dim = build_test_collection(min_size=2, max_size=12547, dim=512, nb_files=37)
+    filenames = sorted([str(tmp_dir) + "/" + str(i) + ".npy" for i in range(len(sizes))])
+    ref = np.concatenate([np.load(f) for f in filenames])
+    batch_size = 62
+    it = read_embeddings_local(tmp_dir, batch_size=batch_size)
+    total_expected = sum(sizes)
+    last = total_expected // batch_size
+    last_expected_batch = total_expected - last * batch_size
+    assert ref.shape[0] == total_expected
+
+    total_found = 0
+    current = 0
+    for i, batch in enumerate(it):
+        if last == i:
+            expected_batch_size = last_expected_batch
+        else:
+            expected_batch_size = batch_size
+        assert batch.shape[0] == expected_batch_size
+        assert batch.shape[1] == dim
+        np.testing.assert_array_equal(ref[current : (current + expected_batch_size)], batch)
+        current += expected_batch_size
+        total_found += batch.shape[0]
+    assert total_expected == total_found


### PR DESCRIPTION
There were 2 issues:
* using np.concatenate means using x2 the memory (especially an issue when we do 1 big batch for training)
* the float32 conversion was doing x2 the memory

The solution adopted is to:
* remove the stack input parameter and replace it by a batch size one
* use this known in advance batch size to pre allocate a np array of that size
* loop over files to fill up this np array, yield when batch size is reached
* load files as memory mapped to avoid doing a x2 when converting to float32

This solves the 2 issues:
* the memory is now capped at batch_size * dim * 4, with no spike above that possible
* if reading float16 embeddings (for example output of clip), no copy is necessary thanks to np load with memory mapping