### PR TITLE
clean ids_batch and ids_batch_df between each batch

### DIFF
--- a/autofaiss/readers/embeddings_iterators.py
+++ b/autofaiss/readers/embeddings_iterators.py
@@ -331,6 +331,8 @@ def read_embeddings(
                     total_embeddings_processed += nb_emb_in_batch
                     nb_emb_in_batch = 0
                     embeddings_batch = None
+                    ids_batch = None
+                    ids_batch_df = None
                 if additional == 0:
                     break
 


### PR DESCRIPTION
it was already working because it overwrote the content of the previous batch, but this is safer