### PR TITLE
fix the number of batches in merge n indices

### DIFF
--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -207,6 +207,7 @@ def _merge_to_n_indices(spark_session, n: int, src_folder: str):
         return src_folder
     dst_folder = _get_stage2_folder(src_folder)
     batch_size = math.ceil(nb_indices_on_src_folder / n)
+    n = math.ceil(nb_indices_on_src_folder / batch_size)
     merge_batches = _batch_loader(batch_size=batch_size, nb_batches=n)
     rdd = spark_session.sparkContext.parallelize(merge_batches, n)
     rdd.foreach(


### PR DESCRIPTION
this was causing an issue when merging

for example if nb_indices_on_src_folder = 554 and n = 100
then batch_size = 6
which means that _batch_loader will generate one batch from 594 and 600 which will be empty and result in crash