### PR TITLE
fixes to n indices merging and optimizing

### DIFF
--- a/autofaiss/external/optimize.py
+++ b/autofaiss/external/optimize.py
@@ -474,13 +474,8 @@ def optimize_and_measure_indices(
 
     indices_folder = make_path_absolute(indices_folder)
     fs, path_in_fs = fsspec.core.url_to_fs(indices_folder, use_listings_cache=False)
-    # Need prefix because fsspec.ls does not keep prefix for some file systems
-    prefix = indices_folder[: indices_folder.index(path_in_fs)]
-    indices_file_paths = fs.ls(indices_folder, detail=False)
+    indices_file_paths = fs.ls(path_in_fs, detail=False)
     suffix_width = int(math.log10(len(indices_file_paths))) + 1
-    indices_file_paths = [
-        prefix.rstrip("/") + "/" + index_file_path.lstrip("/") for index_file_path in sorted(indices_file_paths)
-    ]
 
     def _read_one_index(index_file_path: str):
         with fs.open(index_file_path, "rb") as f:

--- a/autofaiss/external/optimize.py
+++ b/autofaiss/external/optimize.py
@@ -474,7 +474,7 @@ def optimize_and_measure_indices(
 
     indices_folder = make_path_absolute(indices_folder)
     fs, path_in_fs = fsspec.core.url_to_fs(indices_folder, use_listings_cache=False)
-    indices_file_paths = fs.ls(path_in_fs, detail=False)
+    indices_file_paths = sorted(fs.ls(path_in_fs, detail=False))
     suffix_width = int(math.log10(len(indices_file_paths))) + 1
 
     def _read_one_index(index_file_path: str):

--- a/autofaiss/external/optimize.py
+++ b/autofaiss/external/optimize.py
@@ -473,7 +473,7 @@ def optimize_and_measure_indices(
         raise ValueError("index_infos_path is None")
 
     indices_folder = make_path_absolute(indices_folder)
-    fs, path_in_fs = fsspec.core.url_to_fs(indices_folder)
+    fs, path_in_fs = fsspec.core.url_to_fs(indices_folder, use_listings_cache=False)
     # Need prefix because fsspec.ls does not keep prefix for some file systems
     prefix = indices_folder[: indices_folder.index(path_in_fs)]
     indices_file_paths = fs.ls(indices_folder, detail=False)
@@ -483,7 +483,7 @@ def optimize_and_measure_indices(
     ]
 
     def _read_one_index(index_file_path: str):
-        with fsspec.open(index_file_path, "rb").open() as f:
+        with fs.open(index_file_path, "rb") as f:
             return faiss.read_index(faiss.PyCallbackIOReader(f.read))
 
     index_path2_metric_infos: Dict[str, Dict] = {}

--- a/autofaiss/external/quantize.py
+++ b/autofaiss/external/quantize.py
@@ -253,7 +253,7 @@ def build_index(
             logger.info(f"Id columns provided {id_columns} - will be reading the corresponding columns")
             if ids_path is not None:
                 logger.info(f"\tWill be writing the Ids DataFrame in parquet format to {ids_path}")
-                fs, _ = fsspec.core.url_to_fs(ids_path)
+                fs, _ = fsspec.core.url_to_fs(ids_path, use_listings_cache=False)
                 if fs.exists(ids_path):
                     fs.rm(ids_path, recursive=True)
                 fs.mkdirs(ids_path)
@@ -310,7 +310,7 @@ def build_index(
             for path, metric_infos in index_path2_metric_infos.items():
                 logger.info(f"Recap for index: {path}")
                 _log_output_dict(metric_infos)
-            fs, _ = fsspec.core.url_to_fs(temporary_indices_folder)
+            fs, _ = fsspec.core.url_to_fs(temporary_indices_folder, use_listings_cache=False)
             fs.rm(temporary_indices_folder, recursive=True)
             return index_path2_metric_infos
 
@@ -432,13 +432,13 @@ def score_index(
         index_path = make_path_absolute(index_path)
         with fsspec.open(index_path, "rb").open() as f:
             index = faiss.read_index(faiss.PyCallbackIOReader(f.read))
-        fs, path_in_fs = fsspec.core.url_to_fs(index_path)
+        fs, path_in_fs = fsspec.core.url_to_fs(index_path, use_listings_cache=False)
         index_memory = fs.size(path_in_fs)
     else:
         index = index_path
         with tempfile.NamedTemporaryFile("wb") as f:
             faiss.write_index(index, faiss.PyCallbackIOWriter(f.write))
-            fs, path_in_fs = fsspec.core.url_to_fs(f.name)
+            fs, path_in_fs = fsspec.core.url_to_fs(f.name, use_listings_cache=False)
             index_memory = fs.size(path_in_fs)
 
     if isinstance(embeddings, np.ndarray):

--- a/autofaiss/external/scores.py
+++ b/autofaiss/external/scores.py
@@ -76,7 +76,7 @@ def compute_medium_metrics(
     if ground_truth is None:
         if isinstance(embedding_reader, EmbeddingReader):
             ground_truth_path = f"{embedding_reader.embeddings_folder}/small_ground_truth_test.gt"
-            fs, path = fsspec.core.url_to_fs(ground_truth_path)
+            fs, path = fsspec.core.url_to_fs(ground_truth_path, use_listings_cache=False)
             if not fs.exists(path):
 
                 with Timeit("-> Compute small ground truth", indent=1):

--- a/autofaiss/indices/index_utils.py
+++ b/autofaiss/indices/index_utils.py
@@ -150,7 +150,10 @@ def parallel_download_indices_from_remote(
 
     def _download_one(src_dst_path: Tuple[str, str], fs: fsspec.AbstractFileSystem):
         src_path, dst_path = src_dst_path
-        fs.get(src_path, dst_path)
+        try:
+            fs.get(src_path, dst_path)
+        except Exception as e:
+            raise Exception(f"Failed to download {src_path} to {dst_path}") from e
 
     if len(indices_file_paths) == 0:
         return

--- a/autofaiss/utils/path.py
+++ b/autofaiss/utils/path.py
@@ -5,7 +5,7 @@ import fsspec
 
 
 def make_path_absolute(path: str) -> str:
-    fs, p = fsspec.core.url_to_fs(path)
+    fs, p = fsspec.core.url_to_fs(path, use_listings_cache=False)
     if fs.protocol == "file":
         return os.path.abspath(p)
     return path


### PR DESCRIPTION
* use_listings_cache=False to avoid caching the file listings which is an issue on some fs (eg s3)
*  fsspec.open -> fs.open
* use multiple subfolder in temp folder in order to avoid confusing when listing files in it