### PR TITLE
use index.add_with_ids to have consecutive ids in N indices mode

### DIFF
--- a/autofaiss/external/quantize.py
+++ b/autofaiss/external/quantize.py
@@ -145,10 +145,13 @@ def build_index(
         If it is not equal to 1,
             - You are expected to have at most `nb_indices_to_keep` indices with the following names:
                 "{index_path}i" where i ranges from 1 to `nb_indices_to_keep`
-            - `build_index` returns a mapping from index path to metrics instead of a tuple (index, metrics)
+            - `build_index` returns a mapping from index path to metrics
         Default to 1.
     """
     setup_logging(verbose)
+    # if using distributed mode, it doesn't make sense to use indices that are not memory mappable
+    if distributed == "pyspark":
+        should_be_memory_mappable = True
     if index_path is not None:
         index_path = make_path_absolute(index_path)
     elif save_on_disk:

--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -94,7 +94,9 @@ def _add_index(
 
     ids_total = []
     for (vec_batch, ids_batch) in embedding_reader(batch_size=batch_size, start=start, end=end):
-        empty_index.add(vec_batch)
+        consecutive_ids = ids_batch["i"].to_numpy()
+        # using add_with_ids makes it possible to have consecutive and unique ids over all the N indices
+        empty_index.add_with_ids(vec_batch, consecutive_ids)
         if embedding_ids_df_handler:
             ids_total.append(ids_batch)
 
@@ -169,7 +171,7 @@ def _merge_index(
             # so, we have to check whether it is file or not
             if os.path.isfile(rest_index_file):
                 index = faiss.read_index(rest_index_file)
-                faiss.merge_into(merged, index, shift_ids=True)
+                faiss.merge_into(merged, index, shift_ids=False)
         return merged
 
     # estimate index size by taking the first index

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyarrow>=6.0.1,<8
 tqdm>=4.62.3,<5
 faiss-cpu>=1.7.2,<2
 fsspec>=2022.1.0
-embedding_reader>=1.1.0,<2
+embedding_reader>=1.2.0,<2


### PR DESCRIPTION
this makes it possible to use faiss.merge_ondisk (https://github.com/facebookresearch/faiss/blob/30abcd6a865afef7cf86df7e8b839a41b5161505/contrib/ondisk.py )
https://github.com/facebookresearch/faiss/blob/151e3d7be54aec844b6328dc3e7dd0b83fcfa5bc/demos/demo_ondisk_ivf.py
to merge indices on disk without using memory, and then use a very large index with almost no memory usage.
required if the number of indices piece makes the overhead (around 500MB) of loading memmaped indices too large.

example of merge on disk usage that is made possible after this pr:
```python
from faiss.contrib.ondisk import merge_ondisk
import faiss
block_fnames = [ "index_%03d" % i for i in range(10)]
empty_index = faiss.read_index(block_fnames[0], faiss.IO_FLAG_MMAP)
empty_index.ntotal = 0

merge_ondisk(empty_index, block_fnames, "merged_index.ivfdata")

faiss.write_index(empty_index, "populated.index")

pop = faiss.read_index("populated.index", faiss.IO_FLAG_MMAP)
```
that makes it possible to use a very large index at low cost. However run this requires having enough disk space to store the whole index, so it probably makes sense only in some cases (in my case it's necessary)