### PR TITLE
fix how to read populated.index in distributed_autofaiss_n_indices

### DIFF
--- a/examples/distributed_autofaiss_n_indices.py
+++ b/examples/distributed_autofaiss_n_indices.py
@@ -77,7 +77,7 @@ merge_ondisk(empty_index, block_fnames, "merged_index.ivfdata")
 
 faiss.write_index(empty_index, "populated.index")
 
-pop = faiss.read_index("populated.index", faiss.IO_FLAG_MMAP)
+pop = faiss.read_index("populated.index", faiss.IO_FLAG_ONDISK_SAME_DIR)
 
 ########################################################
 # Use case 4: use N indices using  HStackInvertedLists #


### PR DESCRIPTION
the populated index should use faiss.IO_FLAG_ONDISK_SAME_DIR because it points to merged_index.ivfdata
however it doesn't make sense to use faiss.IO_FLAG_MMAP for it, as the ivf inverted lists are already using the on disk implementation