### PR TITLE
Fix the number of output index files

### DIFF
--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -219,7 +219,7 @@ def _merge_to_n_indices(spark_session, n: int, src_folder: str, dst_folder: str,
         # no need to merge
         return src_folder, None
 
-    batch_size = max(1, int(nb_indices_on_src_folder / n))
+    batch_size = max(1, math.ceil(nb_indices_on_src_folder / n))
     n = math.ceil(nb_indices_on_src_folder / batch_size)
     merge_batches = _batch_loader(batch_size=batch_size, nb_batches=n)
 

--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -219,9 +219,7 @@ def _merge_to_n_indices(spark_session, n: int, src_folder: str, dst_folder: str,
         # no need to merge
         return src_folder, None
 
-    batch_size = max(1, math.ceil(nb_indices_on_src_folder / n))
-    n = math.ceil(nb_indices_on_src_folder / batch_size)
-    merge_batches = _batch_loader(batch_size=batch_size, nb_batches=n)
+    merge_batches = _get_merge_batches(input_size=nb_indices_on_src_folder, output_size=n)
 
     rdd = spark_session.sparkContext.parallelize(merge_batches, n)
 
@@ -247,6 +245,12 @@ def _merge_to_n_indices(spark_session, n: int, src_folder: str, dst_folder: str,
         if fs.isfile(file):
             fs.rm(file)
     return dst_folder, metrics_dict
+
+
+def _get_merge_batches(input_size: int, output_size: int) -> Iterator[Tuple[int, int, int]]:
+    batch_size = max(1, math.ceil(input_size / output_size))
+    merge_batches = _batch_loader(batch_size=batch_size, nb_batches=output_size)
+    return merge_batches
 
 
 def run(

--- a/tests/unit/test_distirubted.py
+++ b/tests/unit/test_distirubted.py
@@ -1,0 +1,11 @@
+from autofaiss.indices.distributed import _get_merge_batches
+
+
+def test_get_merge_batches():
+    for input_size in range(2, 500):
+        for output_size in range(1, input_size):
+            batches = list(_get_merge_batches(input_size, output_size))
+            # test output size is expected
+            assert len(batches) == output_size
+            # test no empty batch
+            assert all(batch[0] <= input_size - 1 for batch in batches)


### PR DESCRIPTION
When `nb_indices_on_src_folder` = 101 and `n` (`nb_nbindices_to_keep`) =10,
it generated 11 output files instead of 10.

Now it can generate 10 outputs.