### PR TITLE
Fix "Fix the number of output index files (#119)"

### DIFF
--- a/autofaiss/external/build.py
+++ b/autofaiss/external/build.py
@@ -64,9 +64,11 @@ def estimate_memory_required_for_index_creation(
     else:
         memory_for_training = 0
 
-    index_memory_with_n_indices = index_memory / nb_indices_to_keep
+    # the calculation for max_index_memory_in_one_index comes from the way we split batches
+    # see _batch_loader in distributed.py
+    max_index_memory_in_one_index = index_memory // nb_indices_to_keep + index_memory % nb_indices_to_keep
 
-    return int(max(index_memory_with_n_indices + needed_for_adding, memory_for_training)), index_key
+    return int(max(max_index_memory_in_one_index + needed_for_adding, memory_for_training)), index_key
 
 
 def get_estimated_construction_time_infos(nb_vectors: int, vec_dim: int, indent: int = 0) -> str:

--- a/tests/unit/test_distirubted.py
+++ b/tests/unit/test_distirubted.py
@@ -11,7 +11,7 @@ def test_batch_loader():
             assert all(batch[1] <= input_size - 1 for batch in batches)
             # test on continuous between batches
             assert all(
-                prev_end == next_start for (_, _, prev_end), (_, next_start, next_end) in zip(batches, batches[1:])
+                prev_end == next_start for (_, _, prev_end), (_, next_start, _) in zip(batches, batches[1:])
             )
             # test last element is covered
             assert batches[-1][2] >= input_size

--- a/tests/unit/test_distirubted.py
+++ b/tests/unit/test_distirubted.py
@@ -1,11 +1,19 @@
-from autofaiss.indices.distributed import _get_merge_batches
+from autofaiss.indices.distributed import _batch_loader
 
 
-def test_get_merge_batches():
+def test_batch_loader():
     for input_size in range(2, 500):
         for output_size in range(1, input_size):
-            batches = list(_get_merge_batches(input_size, output_size))
+            batches = list(_batch_loader(nb_batches=output_size, total_size=input_size))
             # test output size is expected
             assert len(batches) == output_size
             # test no empty batch
-            assert all(batch[0] <= input_size - 1 for batch in batches)
+            assert all(batch[1] <= input_size - 1 for batch in batches)
+            # test on continuous between batches
+            assert all(
+                prev_end == next_start for (_, _, prev_end), (_, next_start, next_end) in zip(batches, batches[1:])
+            )
+            # test last element is covered
+            assert batches[-1][2] >= input_size
+            # test range sum
+            assert sum(end - start for _, start, end in batches) == input_size


### PR DESCRIPTION
In the last [PR](https://github.com/criteo/autofaiss/pull/119), we could have empty batch. There was an error in the unit test, so we didn't find the bug.

To fix it, this PR refactors the function `_batch_loader`, now it outputs exactly the number of batches we expect (in the case where total size is bigger than or equal to the expected number of batches).

The unit test has been improved as well.