### PR TITLE
Fix the estimated number of batches

### DIFF
--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -294,7 +294,7 @@ def run(
     n_workers = len(sc.statusTracker().getExecutorInfos()) - 1
 
     # maximum between the number of spark workers, 10M embeddings per task and the number of indices to keep
-    estimated_nb_batches = max(n_workers, int(embedding_reader.count / (10 ** 7)), nb_indices_to_keep)
+    estimated_nb_batches = max(n_workers, math.ceil(embedding_reader.count / (10 ** 7)), nb_indices_to_keep)
     batches = _batch_loader(total_size=embedding_reader.count, nb_batches=estimated_nb_batches)
     rdd = ss.sparkContext.parallelize(batches, estimated_nb_batches)
     with Timeit("-> Adding indices", indent=2):


### PR DESCRIPTION
Use `math.ceil` instead of int can ensure that number of vectors per task is no bigger than 10M. This help avoid unexpected OOM.