### PR TITLE
fix(index_utils): #143 Windows 10 compatibility

### DIFF
--- a/autofaiss/indices/index_utils.py
+++ b/autofaiss/indices/index_utils.py
@@ -20,7 +20,12 @@ logger = logging.getLogger("autofaiss")
 
 def get_index_size(index: faiss.Index) -> int:
     """Returns the size in RAM of a given index"""
-    with NamedTemporaryFile() as tmp_file:
+
+    delete = True
+    if os.name == "nt" :
+        delete = False
+
+    with NamedTemporaryFile(delete=delete) as tmp_file:
         faiss.write_index(index, tmp_file.name)
         size_in_bytes = Path(tmp_file.name).stat().st_size
 


### PR DESCRIPTION
Fix for issue #143

`NamedTemporaryFile` should not delete the file as described in this StackOverflow:  https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file

This fix solves a Windows 10 compatibility issue.