### PR TITLE
Improve methods to create small and big indexes for more flexibility

### DIFF
--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -682,10 +682,7 @@ def create_partitioned_indexes(
         small_index_metrics_future = (
             p.apply_async(_create_small_indexes, (small_partitions,)) if small_partitions else None
         )
-        for metrics in p.starmap(
-            create_big_index_fn,
-            [(p, _infer_index_output_dir(p)) for p in big_partitions]
-        ):
+        for metrics in p.starmap(create_big_index_fn, [(p, _infer_index_output_dir(p)) for p in big_partitions]):
             all_metrics.append(metrics)
         if small_index_metrics_future:
             all_metrics.extend(small_index_metrics_future.get())

--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -438,21 +438,21 @@ def create_big_index(
     embedding_root_dirs: Union[List[str], str],
     output_root_dir: str,
     ss,
-    id_columns: Optional[List[str]],
-    should_be_memory_mappable: bool,
-    max_index_query_time_ms: float,
-    max_index_memory_usage: str,
-    min_nearest_neighbors_to_retrieve: int,
-    embedding_column_name: str,
-    index_key: str,
-    index_path: Optional[str],
-    current_memory_available: str,
-    nb_cores: Optional[int],
-    use_gpu: bool,
-    metric_type: str,
-    nb_splits_per_big_index: int,
-    make_direct_map: bool,
-    temp_root_dir: str,
+    id_columns: Optional[List[str]] = None,
+    should_be_memory_mappable: bool = False,
+    max_index_query_time_ms: float = 10.0,
+    max_index_memory_usage: str = "16G",
+    min_nearest_neighbors_to_retrieve: int = 20,
+    embedding_column_name: str = "embedding",
+    index_key: Optional[str] = None,
+    index_path: Optional[str] = None,
+    current_memory_available: str = "32G",
+    nb_cores: Optional[int] = None,
+    use_gpu: bool = False,
+    metric_type: str = "ip",
+    nb_splits_per_big_index: int = 1,
+    make_direct_map: bool = False,
+    temp_root_dir: str = "hdfs://root/tmp/distributed_autofaiss_indices",
 ) -> Optional[Dict[str, str]]:
     """
     Create a big index
@@ -473,7 +473,7 @@ def create_big_index(
             id_columns=id_columns,
         )
 
-        index_output_root_dir = os.path.join(temp_root_dir, "training", partition)
+        index_output_root_dir = os.path.join(temp_root_dir, "training", str(uuid4()))
         output_index_path = save_index(trained_index.index_or_path, index_output_root_dir, "trained_index")
         return TrainedIndex(output_index_path, trained_index.index_key, embedding_root_dirs)
 

--- a/autofaiss/indices/distributed.py
+++ b/autofaiss/indices/distributed.py
@@ -478,7 +478,10 @@ def create_big_index(
         return TrainedIndex(output_index_path, trained_index.index_key, embedding_root_dirs)
 
     if not index_path:
-        # Train index
+        # Train index. We use the value 13 below as a magic number to create a partition
+        # and train the big index on an executor. We don't want to train the big index
+        # on the driver because we are potentially training multiple big indexes in parallel
+        # and the driver don't necessarily have enough memory
         rdd = ss.sparkContext.parallelize([13], 1)
         trained_index_path, trained_index_key, _, = rdd.map(
             lambda _: _create_and_train_index_from_embedding_dir()

--- a/autofaiss/indices/training.py
+++ b/autofaiss/indices/training.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("autofaiss")
 class TrainedIndex(NamedTuple):
     index_or_path: Union[faiss.Index, str]
     index_key: str
-    embedding_reader_or_path: Union[EmbeddingReader, str]
+    embedding_reader_or_path: Union[EmbeddingReader, str, List[str]]
 
 
 def create_empty_index(vec_dim: int, index_key: str, metric_type: Union[str, int]) -> faiss.Index:
@@ -110,7 +110,7 @@ def create_and_train_new_index(
 
 
 def create_and_train_index_from_embedding_dir(
-    embedding_root_dir: str,
+    embedding_root_dirs: Union[List[str], str],
     embedding_column_name: str,
     max_index_memory_usage: str,
     make_direct_map: bool,
@@ -131,7 +131,7 @@ def create_and_train_index_from_embedding_dir(
     # Read embeddings
     with Timeit("-> Reading embeddings", indent=2):
         embedding_reader = EmbeddingReader(
-            embedding_root_dir, file_format="parquet", embedding_column=embedding_column_name, meta_columns=id_columns
+            embedding_root_dirs, file_format="parquet", embedding_column=embedding_column_name, meta_columns=id_columns
         )
 
     # Define index key
@@ -145,7 +145,7 @@ def create_and_train_index_from_embedding_dir(
             use_gpu=use_gpu,
         )
         if not best_index_keys:
-            raise RuntimeError(f"Unable to find optimal index key from embedding directory {embedding_root_dir}")
+            raise RuntimeError(f"Unable to find optimal index key from embedding directory {embedding_root_dirs}")
         index_key = best_index_keys[0]
 
     # Create metadata

--- a/autofaiss/utils/cast.py
+++ b/autofaiss/utils/cast.py
@@ -40,10 +40,6 @@ def cast_memory_to_bytes(memory_string: str) -> float:
 def cast_bytes_to_memory_string(num_bytes: float) -> str:
     """
     Cast a number of bytes to a readable string
-
-    >>> from autofaiss.utils.cast import cast_bytes_to_memory_string
-    >>> cast_bytes_to_memory_string(16.*1024*1024*1024) == "16.0GB"
-    True
     """
 
     suffix = "B"


### PR DESCRIPTION
These methods now:
- Accept a final output directory instead of inferring one.
- Accept multiple input embedding directories instead of only one.