### PR TITLE
Fix "AttributeError: module 'faiss' has no attribute 'swigfaiss'" for faiss>=1.7.3

### DIFF
--- a/autofaiss/indices/index_utils.py
+++ b/autofaiss/indices/index_utils.py
@@ -159,10 +159,10 @@ def parallel_download_indices_from_remote(
 
 
 def initialize_direct_map(index: faiss.Index) -> None:
-    nested_index = extract_index_ivf(index) if isinstance(index, faiss.swigfaiss.IndexPreTransform) else index
+    nested_index = extract_index_ivf(index) if isinstance(index, faiss.IndexPreTransform) else index
 
     # Make direct map is only implemented for IndexIVF and IndexBinaryIVF, see built file faiss/swigfaiss.py
-    if isinstance(nested_index, (faiss.swigfaiss.IndexIVF, faiss.swigfaiss.IndexBinaryIVF)):
+    if isinstance(nested_index, (faiss.IndexIVF, faiss.IndexBinaryIVF)):
         nested_index.make_direct_map()
 
 


### PR DESCRIPTION
Autofaiss was not working when `make_direct_map=True` for faiss>=1.7.3 

Indeed, before 1.7.2 we could access some internal functions/objects with `faiss.swigfaiss.xxx` or `faiss.xxx`.
But since 1.7.3 we can only rely on `faiss.xxx`, otherwise we get the error `AttributeError: module 'faiss' has no attribute 'swigfaiss'`