### PR TITLE
Release 2.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [2.15.7] - 2023-06-06
+
+### Changed
+* Fix issue where creating forced memory-mapped indices with faiss-cpu>1.7.2 was failing (#164)
+* Support python 3.10 in CI (#165)
+* Loosen pyarrow version constraints
+
 ## [2.15.6] - 2023-05-04
 
 ### Changed

--- a/autofaiss/version.py
+++ b/autofaiss/version.py
@@ -1,6 +1,6 @@
 # pylint: disable=all
 
-__version__ = "2.15.6"
+__version__ = "2.15.7"
 __author__ = "Criteo"
 
 


### PR DESCRIPTION
## [2.15.7] - 2023-06-06

### Changed
* Fix issue where creating forced memory-mapped indices with faiss-cpu>1.7.2 was failing (#164)
* Support python 3.10 in CI (#165)
* Loosen pyarrow version constraints