### PR TITLE
Improve windows compatibility

### DIFF
--- a/autofaiss/indices/index_utils.py
+++ b/autofaiss/indices/index_utils.py
@@ -21,6 +21,11 @@ logger = logging.getLogger("autofaiss")
 def get_index_size(index: faiss.Index) -> int:
     """Returns the size in RAM of a given index"""
     with NamedTemporaryFile() as tmp_file:
+        # it's not allowed to re-open the file on windows
+        # https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file
+        if os.name == "nt":
+            tmp_file.close()
+
         faiss.write_index(index, tmp_file.name)
         size_in_bytes = Path(tmp_file.name).stat().st_size
 


### PR DESCRIPTION
A different approach to fix https://github.com/criteo/autofaiss/issues/143.

Instead of keeping the temporary file, we can just close it. Apparently, the problem is that Windows does not allow repeatedly opening files. I believe that this solution should be preferred over https://github.com/criteo/autofaiss/pull/144, which turns the temporary file into a non-temporary one.